### PR TITLE
Only Play Music for Player Scenes

### DIFF
--- a/Source/Scripts/OJazz_Main.psc
+++ b/Source/Scripts/OJazz_Main.psc
@@ -70,17 +70,21 @@ Function MainController()
 endFunction
 
 Event OnOstimStart(string eventName, string strArg, float numArg, Form sender)
-    MainController()
-    Utility.Wait(7)
-    OJazzWidget.FlashVisibililty(5)
+    if ostim.IsPlayerInvolved()
+        MainController()
+        Utility.Wait(7)
+        OJazzWidget.FlashVisibililty(5)
+    endif
 endEvent
 
 Event OnOstimEnd(string eventName, string strArg, float numArg, Form sender)
-    ;Double check the song was stopped.
-    Sound.StopInstance(SongIndex)
-    Writelog("Stopping Music")
-    if OJazzWidget.visible
-        OJazzWidget.FlashVisibililty()
+    if ostim.IsActorActive(PlayerRef) == false
+        ;Double check the song was stopped.
+        Sound.StopInstance(SongIndex)
+        Writelog("Stopping Music")
+        if OJazzWidget.visible
+            OJazzWidget.FlashVisibililty()
+        endif
     endif
 endEvent
 


### PR DESCRIPTION
Change the ostim_start behaviour to only play songs when the player is involved, and change the ostim_end behaviour to only end songs if the player is not active.

This should cover most cases of NPCs' scenes overlapping with the player's (eg. music won't start for npc scenes, and npc scenes ending won't end the music during a player scene).